### PR TITLE
Fixed playing sound for entities on server.

### DIFF
--- a/src/main/java/codechicken/lib/util/SoundUtils.java
+++ b/src/main/java/codechicken/lib/util/SoundUtils.java
@@ -2,6 +2,7 @@ package codechicken.lib.util;
 
 import codechicken.lib.vec.Vector3;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
@@ -16,7 +17,14 @@ public class SoundUtils {
     }
 
     public static void playSoundAt(Entity entity, SoundCategory category, SoundEvent sound, float volume, float pitch) {
-        playSoundAt(entity, category, sound, volume, pitch, false);
+        EntityPlayer player = null;
+
+        //only assigning player on client as if triggered on server the player passed here would be omitted from hearing the sound
+        if (entity.worldObj.isRemote && entity instanceof EntityPlayer) {
+            player = (EntityPlayer) entity;
+        }
+
+        entity.worldObj.playSound(player, entity.posX, entity.posY, entity.posZ, sound, category, volume, pitch);
     }
 
     public static void playSoundAt(Entity entity, SoundCategory category, SoundEvent sound) {


### PR DESCRIPTION
The previous call would end up calling world.playSound without the first entity parameter which doesn't do anything when called on server. 
I have left that one in as it has distanceDelay parameter which the new call doesn't have and I can't be sure that one isn't being called on client somewhere.