### PR TITLE
Fix for severe World object memory leak

### DIFF
--- a/src/main/java/codechicken/lib/world/WorldExtensionManager.java
+++ b/src/main/java/codechicken/lib/world/WorldExtensionManager.java
@@ -23,37 +23,37 @@ public class WorldExtensionManager {
 
         @SubscribeEvent
         public void onChunkDataLoad(ChunkDataEvent.Load event) {
-            if (!worldMap.containsKey(event.getWorld())) {
+            if (!worldMap.containsKey(event.getWorld().provider.getDimension())) {
                 WorldExtensionManager.onWorldLoad(event.getWorld());
             }
 
             createChunkExtension(event.getWorld(), event.getChunk());
 
-            for (WorldExtension extension : worldMap.get(event.getWorld())) {
+            for (WorldExtension extension : worldMap.get(event.getWorld().provider.getDimension())) {
                 extension.loadChunkData(event.getChunk(), event.getData());
             }
         }
 
         @SubscribeEvent
         public void onChunkDataSave(ChunkDataEvent.Save event) {
-            for (WorldExtension extension : worldMap.get(event.getWorld())) {
+            for (WorldExtension extension : worldMap.get(event.getWorld().provider.getDimension())) {
                 extension.saveChunkData(event.getChunk(), event.getData());
             }
 
             if (!event.getChunk().isLoaded()) {
-                removeChunk(event.getWorld(), event.getChunk());
+                removeChunk(event.getWorld().provider.getDimension(), event.getChunk());
             }
         }
 
         @SubscribeEvent
         public void onChunkLoad(ChunkEvent.Load event) {
-            if (!worldMap.containsKey(event.getWorld())) {
+            if (!worldMap.containsKey(event.getWorld().provider.getDimension())) {
                 WorldExtensionManager.onWorldLoad(event.getWorld());
             }
 
             createChunkExtension(event.getWorld(), event.getChunk());
 
-            for (WorldExtension extension : worldMap.get(event.getWorld())) {
+            for (WorldExtension extension : worldMap.get(event.getWorld().provider.getDimension())) {
                 extension.loadChunk(event.getChunk());
             }
         }
@@ -64,7 +64,7 @@ public class WorldExtensionManager {
                 return;
             }
             //TODO Maybe gate against worldMap.get returning null. Some dimension may be doing stupid things.
-            for (WorldExtension extension : worldMap.get(event.getWorld())) {
+            for (WorldExtension extension : worldMap.get(event.getWorld().provider.getDimension())) {
                 extension.unloadChunk(event.getChunk());
             }
 
@@ -75,8 +75,8 @@ public class WorldExtensionManager {
 
         @SubscribeEvent
         public void onWorldSave(WorldEvent.Save event) {
-            if (worldMap.containsKey(event.getWorld())) {
-                for (WorldExtension extension : worldMap.get(event.getWorld())) {
+            if (worldMap.containsKey(event.getWorld().provider.getDimension())) {
+                for (WorldExtension extension : worldMap.get(event.getWorld().provider.getDimension())) {
                     extension.save();
                 }
             }
@@ -84,16 +84,16 @@ public class WorldExtensionManager {
 
         @SubscribeEvent
         public void onWorldLoad(WorldEvent.Load event) {
-            if (!worldMap.containsKey(event.getWorld())) {
+            if (!worldMap.containsKey(event.getWorld().provider.getDimension())) {
                 WorldExtensionManager.onWorldLoad(event.getWorld());
             }
         }
 
         @SubscribeEvent
         public void onWorldUnLoad(WorldEvent.Unload event) {
-            if (worldMap.containsKey(event.getWorld()))//because force closing unloads a world twice
+            if (worldMap.containsKey(event.getWorld().provider.getDimension()))//because force closing unloads a world twice
             {
-                for (WorldExtension extension : worldMap.remove(event.getWorld())) {
+                for (WorldExtension extension : worldMap.remove(event.getWorld().provider.getDimension())) {
                     extension.unload();
                 }
             }
@@ -102,7 +102,7 @@ public class WorldExtensionManager {
         @SubscribeEvent
         public void onChunkWatch(Watch event) {
             Chunk chunk = event.getPlayer().worldObj.getChunkFromChunkCoords(event.getChunk().chunkXPos, event.getChunk().chunkZPos);
-            for (WorldExtension extension : worldMap.get(event.getPlayer().worldObj)) {
+            for (WorldExtension extension : worldMap.get(event.getPlayer().worldObj.provider.getDimension())) {
                 extension.watchChunk(chunk, event.getPlayer());
             }
         }
@@ -111,7 +111,7 @@ public class WorldExtensionManager {
         @SideOnly (Side.CLIENT)
         public void onChunkUnWatch(UnWatch event) {
             Chunk chunk = event.getPlayer().worldObj.getChunkFromChunkCoords(event.getChunk().chunkXPos, event.getChunk().chunkZPos);
-            for (WorldExtension extension : worldMap.get(event.getPlayer().worldObj)) {
+            for (WorldExtension extension : worldMap.get(event.getPlayer().worldObj.provider.getDimension())) {
                 extension.unwatchChunk(chunk, event.getPlayer());
             }
         }
@@ -120,7 +120,7 @@ public class WorldExtensionManager {
         @SideOnly (Side.CLIENT)
         public void clientTick(TickEvent.ClientTickEvent event) {
             World world = Minecraft.getMinecraft().theWorld;
-            if (worldMap.containsKey(world)) {
+            if (worldMap.containsKey(world.provider.getDimension())) {
                 if (event.phase == TickEvent.Phase.START) {
                     preTick(world);
                 } else {
@@ -131,7 +131,7 @@ public class WorldExtensionManager {
 
         @SubscribeEvent
         public void serverTick(TickEvent.WorldTickEvent event) {
-            if (!worldMap.containsKey(event.world)) {
+            if (!worldMap.containsKey(event.world.provider.getDimension())) {
                 WorldExtensionManager.onWorldLoad(event.world);
             }
 
@@ -160,7 +160,7 @@ public class WorldExtensionManager {
         MinecraftForge.EVENT_BUS.register(new WorldExtensionEventHandler());
     }
 
-    private static HashMap<World, WorldExtension[]> worldMap = new HashMap<World, WorldExtension[]>();
+    private static HashMap<Integer, WorldExtension[]> worldMap = new HashMap<Integer, WorldExtension[]>();
 
     private static void onWorldLoad(World world) {
         WorldExtension[] extensions = new WorldExtension[extensionIntialisers.size()];
@@ -168,7 +168,7 @@ public class WorldExtensionManager {
             extensions[i] = extensionIntialisers.get(i).createWorldExtension(world);
         }
 
-        worldMap.put(world, extensions);
+        worldMap.put(world.provider.getDimension(), extensions);
 
         for (WorldExtension extension : extensions) {
             extension.load();
@@ -176,7 +176,7 @@ public class WorldExtensionManager {
     }
 
     private static void createChunkExtension(World world, Chunk chunk) {
-        WorldExtension[] extensions = worldMap.get(world);
+        WorldExtension[] extensions = worldMap.get(world.provider.getDimension());
         for (int i = 0; i < extensionIntialisers.size(); i++) {
             if (!extensions[i].containsChunk(chunk)) {
                 extensions[i].addChunk(extensionIntialisers.get(i).createChunkExtension(chunk, extensions[i]));
@@ -185,24 +185,24 @@ public class WorldExtensionManager {
     }
 
     private static void removeChunk(World world, Chunk chunk) {
-        for (WorldExtension extension : worldMap.get(world)) {
+        for (WorldExtension extension : worldMap.get(world.provider.getDimension())) {
             extension.remChunk(chunk);
         }
     }
 
     private static void preTick(World world) {
-        for (WorldExtension extension : worldMap.get(world)) {
+        for (WorldExtension extension : worldMap.get(world.provider.getDimension())) {
             extension.preTick();
         }
     }
 
     private static void postTick(World world) {
-        for (WorldExtension extension : worldMap.get(world)) {
+        for (WorldExtension extension : worldMap.get(world.provider.getDimension())) {
             extension.postTick();
         }
     }
 
     public static WorldExtension getWorldExtension(World world, int instantiatorID) {
-        return worldMap.get(world)[instantiatorID];
+        return worldMap.get(world.provider.getDimension())[instantiatorID];
     }
 }


### PR DESCRIPTION
**Description of the issue:**
Using the World object as the key of a HashMap causes the World object to not be processed by the garbage collector, causing frequent memory leaks on Sponge servers, especially those running FTB Beyond.

**How this PR fixes the issue:**
Use the dimension id as the key of the Map, as it's an unique identifier of the dimension.

**Extra information:**
This issue seems to especially affect FTB Beyond servers with Sponge. The servers were experiencing frequent crashes (and data loss) and extremely low TPS because the servers process were using a huge amount of RAM. Unfortunately, it was hard to track the exact cause of the memory leak because of the heap dump size (around 12GB), that required a high amount of RAM to be processed. Thanks to @Rubbertjuh (ToastyNetworks.net) that supported me in finding a solution to the memory leak, we rent a 128GB RAM/32 CPU Core server that I set up to perform the memory leak analysis, and found it was caused by this library.

[Click here to download the leak analysis result](https://github.com/TheCBProject/CodeChickenLib/files/1251502/CodeChickenLib.WorldExtensionManager.memory.leak.zip) (extract and open index.html)