### PR TITLE
Update for 1.12.1

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-mc_version=1.12
-forge_version=14.21.1.2387
-mappings=snapshot_20170624
-mod_version=3.1.2
+mc_version=1.12.1
+forge_version=14.22.0.2452
+mappings=snapshot_20170916
+mod_version=3.1.3


### PR DESCRIPTION
I am relatively new to creating or updating forge mods, but I believe I made the minimum edits to get CodeChickenLib working in Minecraft 1.12.1. I played with a locally compiled version with this patch for about 15 minutes on 1.12.1 today and did not experience any crashing or other issues.