### PR TITLE
Remove old coremod settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,6 @@ processResources {
 
 version = "${project.minecraft.version}-${project.version}"
 def commonManifest = {
-    attributes 'FMLCorePlugin': 'codechicken.lib.asm.CCLCorePlugin'
-    attributes 'FMLCorePluginContainsFMLMod': 'true'
     attributes 'FMLAT': 'ccl_at.cfg'
 }
 


### PR DESCRIPTION
The setting caused forge to try and load CCL as a coremod, which lend to an error log(Coremod codechicken.lib.asm.CCLCorePlugin: Unable to class load the plugin java.lang.ClassNotFoundException: codechicken.lib.asm.CCLCorePlugin). I did not test this, but there should be no problems.