### PR TITLE
Backported a texture load fix from master branch

### DIFF
--- a/src/main/java/codechicken/lib/texture/TextureUtils.java
+++ b/src/main/java/codechicken/lib/texture/TextureUtils.java
@@ -2,6 +2,7 @@ package codechicken.lib.texture;
 
 import codechicken.lib.colour.Colour;
 import codechicken.lib.colour.ColourARGB;
+import codechicken.lib.internal.CCLLog;
 import com.google.common.base.Function;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -21,6 +22,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.logging.log4j.Level;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
@@ -60,6 +62,13 @@ public class TextureUtils {
 
     @SubscribeEvent
     public void textureLoad(TextureStitchEvent.Pre event) {
+        if (!event.getMap().getBasePath().equals("textures")) {
+            CCLLog.log(Level.WARN, "Someone is calling the TextureStitchEvent.Pre for a texture map that is NOT vanillas.");
+            CCLLog.log(Level.WARN, "This is a bug. There is no sense of different atlas's in vanilla so this event is NOT generic and is specific to the vanilla atlas.");
+            CCLLog.log(Level.WARN, "Im catching this so things don't explode. Fix your shit!");
+            CCLLog.big(Level.WARN, 100, "");
+            return;
+        }
         for (IIconRegister reg : iconRegisters) {
             reg.registerIcons(event.getMap());
         }


### PR DESCRIPTION
If #116 and https://github.com/simeonradivoev/MatterOverdrive/issues/635 are an issue in 1.11.2, this fixes them.