### PR TITLE
Fix PropertyInteger.parseValue only handling ints

### DIFF
--- a/src/main/java/codechicken/lib/block/property/PropertyInteger.java
+++ b/src/main/java/codechicken/lib/block/property/PropertyInteger.java
@@ -39,8 +39,13 @@ public class PropertyInteger extends PropertyHelper<Integer> {
     @Override
     @Nonnull
     public Optional<Integer> parseValue(@Nonnull String value) {
-        if (valueSet.contains(Integer.valueOf(value))) {
-            return Optional.of(Integer.valueOf(value));
+        try {
+            Integer intValue = Integer.valueOf(value);
+            if (valueSet.contains(intValue) {
+                return Optional.of(intValue);
+            }
+        } catch (NumberFormatException ignored) {
+            // Invalid value, let it fall through
         }
         return Optional.absent();
     }


### PR DESCRIPTION
This catches the potential NumberFormatException that might get thrown if some-one passes something that isn't an integer, such as "hello" into the function. This now matches the behaviour of vanilla minecraft's PropertyInteger.parseValue, which catches the error.

I'm not sure when this could happen in vanilla, however it looks like some commands and advancement criteria call this in order to parse their respective strings.

This was found with an in-dev version of buildcraft, with [this crash](https://gist.github.com/LuigiHutch/467a1fe6c97388f11ea47e21128ece8e).