### PR TITLE
Fix crashing when the supporters marker file is malformed

### DIFF
--- a/src/main/java/codechicken/lib/internal/ModDescriptionEnhancer.java
+++ b/src/main/java/codechicken/lib/internal/ModDescriptionEnhancer.java
@@ -38,9 +38,9 @@ public class ModDescriptionEnhancer {
         if (marker.exists()) {
             try {
                 FileReader reader = new FileReader(marker);
-                lastDownload = Long.valueOf(IOUtils.toString(reader));
+                lastDownload = Long.valueOf(IOUtils.toString(reader).trim());
                 IOUtils.closeQuietly(reader);
-            } catch (IOException e) {
+            } catch (IOException | NumberFormatException e) {
                 CCLLog.log(Level.WARN, "Error reading supporters marker file. Deleting..");
                 marker.delete();
                 lastDownload = 0;


### PR DESCRIPTION
When the `config/codechicken/supporters.marker` file does not contain a valid value according to `Long.valueOf`, Minecraft crashes. This happened for me while I was diffing two config directories. To take this file out of the listing, I copied one file's timestamp to the other file. Unfortunately, the editor of the diff tool I was using adds a newline character to the end of any file saved with it. This resulted in a crash. My solution is to trim the string before parsing it, and catch `NumberFormatException`.

For reference, here is the log I got while testing a modpack: https://openeye.openmods.info/crashes/880f569dff28241749eccbc79f1c0e47. And this is from when I tested this crash with only CodeChicken Lib and OpenEye: https://openeye.openmods.info/crashes/e98965134a683026c8529be96e382d16 (I do not know why the stack traces are slightly different).