### PR TITLE
Revert "Attempt to release ByteBufs."

### DIFF
--- a/src/main/java/codechicken/lib/packet/PacketCustom.java
+++ b/src/main/java/codechicken/lib/packet/PacketCustom.java
@@ -214,7 +214,6 @@ public final class PacketCustom extends ByteBuf implements MCDataInput, MCDataOu
     public PacketCustom(ByteBuf payload) {
         byte[] bytes = new byte[payload.readableBytes()];
         payload.readBytes(bytes);
-        payload.release();
         buf = Unpooled.wrappedBuffer(bytes);
 
         type = readUnsignedByte();


### PR DESCRIPTION
This breaks Draconic Evolution and potentially any other mod that relies on PacketCustom.java.