### PR TITLE
Create CodeChickenLib一直崩潰

### DIFF
--- a/CodeChickenLib一直崩潰
+++ b/CodeChickenLib一直崩潰
@@ -1,0 +1,152 @@
+---- Minecraft Crash Report ----
+
+WARNING: coremods are present:
+  IELoadingPlugin (ImmersiveEngineering-core-0.12-98.jar)
+  Inventory Tweaks Coremod (InventoryTweaks-1.63.jar)
+  EnderCorePlugin (EnderCore-1.12.2-0.5.76-core.jar)
+  MekanismCoremod (Mekanism-1.12.2-9.8.3.390.jar)
+  OpenModsCorePlugin (OpenModsLib-1.12.2-0.12.2.jar)
+Contact their authors BEFORE contacting forge
+
+// I bet Cylons wouldn't have this problem.
+
+Time: 4/3/21 12:03 PM
+Description: There was a severe problem during mod loading that has caused the game to fail
+
+net.minecraftforge.fml.common.LoaderExceptionModCrash: Caught exception from CodeChicken Lib (codechickenlib)
+Caused by: codechicken.lib.configuration.ConfigFile$ConfigException: codechicken.lib.configuration.ConfigParseException: Invalid value type d, @Line:20, dump_asm=true
+	at codechicken.lib.configuration.ConfigFile.load(ConfigFile.java:61)
+	at codechicken.lib.configuration.ConfigFile.<init>(ConfigFile.java:43)
+	at codechicken.lib.configuration.ConfigFile.<init>(ConfigFile.java:29)
+	at codechicken.lib.configuration.ConfigFile.<init>(ConfigFile.java:19)
+	at codechicken.lib.CodeChickenLib.preInit(CodeChickenLib.java:50)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:497)
+	at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:637)
+	at sun.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:497)
+	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
+	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
+	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
+	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
+	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
+	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
+	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
+	at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:219)
+	at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:197)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:497)
+	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
+	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
+	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
+	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
+	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
+	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
+	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
+	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:136)
+	at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:629)
+	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:252)
+	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:467)
+	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:378)
+	at net.minecraft.client.main.Main.main(SourceFile:123)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+	at java.lang.reflect.Method.invoke(Method.java:497)
+	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
+	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
+Caused by: codechicken.lib.configuration.ConfigParseException: Invalid value type d, @Line:20, dump_asm=true
+	at codechicken.lib.configuration.ConfigTag.parseTag(ConfigTag.java:92)
+	at codechicken.lib.configuration.ConfigFile.load(ConfigFile.java:59)
+	... 44 more
+
+
+A detailed walkthrough of the error, its code path and all known details is as follows:
+---------------------------------------------------------------------------------------
+
+-- System Details --
+Details:
+	Minecraft Version: 1.12.2
+	Operating System: Windows 10 (amd64) version 10.0
+	Java Version: 1.8.0_51, Oracle Corporation
+	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
+	Memory: 407605128 bytes (388 MB) / 805306368 bytes (768 MB) up to 2147483648 bytes (2048 MB)
+	JVM Flags: 8 total; -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xmx2G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=50 -XX:G1HeapRegionSize=32M
+	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
+	FML: MCP 9.42 Powered by Forge 14.23.5.2854 46 mods loaded, 46 mods active
+	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored
+
+	| State | ID                                | Version                  | Source                                         | Signature                                |
+	|:----- |:--------------------------------- |:------------------------ |:---------------------------------------------- |:---------------------------------------- |
+	| LCH   | minecraft                         | 1.12.2                   | minecraft.jar                                  | None                                     |
+	| LCH   | mcp                               | 9.42                     | minecraft.jar                                  | None                                     |
+	| LCH   | FML                               | 8.0.99.99                | forge-1.12.2-14.23.5.2854.jar                  | e3c3d50c7c986df74c645c0ac54639741c90a557 |
+	| LCH   | forge                             | 14.23.5.2854             | forge-1.12.2-14.23.5.2854.jar                  | e3c3d50c7c986df74c645c0ac54639741c90a557 |
+	| LCH   | openmodscore                      | 0.12.2                   | minecraft.jar                                  | None                                     |
+	| LCE   | codechickenlib                    | 3.2.3.358                | CodeChickenLib-1.12.2-3.2.3.358-universal.jar  | f1850c39b2516232a2108a7bd84d1cb5df93b261 |
+	| LC    | redstoneflux                      | 2.1.1                    | RedstoneFlux-1.12-2.1.1.1-universal.jar        | None                                     |
+	| LC    | cofhcore                          | 4.6.6                    | CoFHCore-1.12.2-4.6.6.1-universal.jar          | None                                     |
+	| LC    | cofhworld                         | 1.4.0                    | CoFHWorld-1.12.2-1.4.0.1-universal.jar         | None                                     |
+	| LC    | lootablebodies                    | 2.4.0                    | DrCyanosLootableBodies_1.12-2.4.0.jar          | None                                     |
+	| LC    | endercore                         | 1.12.2-0.5.76            | EnderCore-1.12.2-0.5.76.jar                    | None                                     |
+	| LC    | jei                               | 4.16.1.301               | jei_1.12.2-4.16.1.301.jar                      | None                                     |
+	| LC    | thermalfoundation                 | 2.6.7                    | ThermalFoundation-1.12.2-2.6.7.1-universal.jar | None                                     |
+	| LC    | thermalexpansion                  | 5.5.7                    | ThermalExpansion-1.12.2-5.5.7.1-universal.jar  | None                                     |
+	| LC    | enderio                           | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderiointegrationtic             | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderiobase                       | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderioconduits                   | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderioconduitsappliedenergistics | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderioconduitsopencomputers      | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderioconduitsrefinedstorage     | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderiointegrationforestry        | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderiointegrationticlate         | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderioinvpanel                   | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderiomachines                   | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | enderiopowertools                 | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
+	| LC    | forgemultipartcbe                 | 2.6.2.83                 | ForgeMultipart-1.12.2-2.6.2.83-universal.jar   | f1850c39b2516232a2108a7bd84d1cb5df93b261 |
+	| LC    | microblockcbe                     | 2.6.2.83                 | ForgeMultipart-1.12.2-2.6.2.83-universal.jar   | None                                     |
+	| LC    | minecraftmultipartcbe             | 2.6.2.83                 | ForgeMultipart-1.12.2-2.6.2.83-universal.jar   | None                                     |
+	| LC    | inventorytweaks                   | 1.63+release.109.220f184 | InventoryTweaks-1.63.jar                       | 55d2cd4f5f0961410bf7b91ef6c6bf00a766dcbe |
+	| LC    | ironchest                         | 1.12.2-7.0.67.844        | ironchest-1.12.2-7.0.72.847.jar                | None                                     |
+	| LC    | journeymap                        | 1.12.2-5.7.1             | journeymap-1.12.2-5.7.1-tw.jar                 | None                                     |
+	| LC    | mantle                            | 1.12-1.3.3.55            | Mantle-1.12-1.3.3.55.jar                       | None                                     |
+	| LC    | mekanism                          | 1.12.2-9.8.3.390         | Mekanism-1.12.2-9.8.3.390.jar                  | None                                     |
+	| LC    | mekanismgenerators                | 1.12.2-9.8.3.390         | MekanismGenerators-1.12.2-9.8.3.390.jar        | None                                     |
+	| LC    | mekanismtools                     | 1.12.2-9.8.3.390         | MekanismTools-1.12.2-9.8.3.390.jar             | None                                     |
+	| LC    | mtrm                              | 1.2.2.30                 | MineTweakerRecipeMaker-1.12.2-1.2.2.30.jar     | None                                     |
+	| LC    | mrtjpcore                         | 2.1.4.43                 | MrTJPCore-1.12.2-2.1.4.43-universal.jar        | None                                     |
+	| LC    | openmods                          | 0.12.2                   | OpenModsLib-1.12.2-0.12.2.jar                  | d2a9a8e8440196e26a268d1f3ddc01b2e9c572a5 |
+	| LC    | openblocks                        | 1.8.1                    | OpenBlocks-1.12.2-1.8.1.jar                    | d2a9a8e8440196e26a268d1f3ddc01b2e9c572a5 |
+	| LC    | projectred-core                   | 4.9.4.120                | ProjectRed-1.12.2-4.9.4.120-Base.jar           | None                                     |
+	| LC    | projectred-compat                 | 1.0                      | ProjectRed-1.12.2-4.9.4.120-compat.jar         | None                                     |
+	| LC    | projectred-integration            | 4.9.4.120                | ProjectRed-1.12.2-4.9.4.120-integration.jar    | None                                     |
+	| LC    | projectred-transmission           | 4.9.4.120                | ProjectRed-1.12.2-4.9.4.120-integration.jar    | None                                     |
+	| LC    | thermaldynamics                   | 2.5.6                    | ThermalDynamics-1.12.2-2.5.6.1-universal.jar   | None                                     |
+	| LC    | immersiveengineering              | 0.12-98                  | ImmersiveEngineering-0.12-98.jar               | None                                     |
+
+	Loaded coremods (and transformers): 
+IELoadingPlugin (ImmersiveEngineering-core-0.12-98.jar)
+  blusunrize.immersiveengineering.common.asm.IEClassTransformer
+Inventory Tweaks Coremod (InventoryTweaks-1.63.jar)
+  invtweaks.forge.asm.ContainerTransformer
+EnderCorePlugin (EnderCore-1.12.2-0.5.76-core.jar)
+  com.enderio.core.common.transform.EnderCoreTransformer
+  com.enderio.core.common.transform.SimpleMixinPatcher
+MekanismCoremod (Mekanism-1.12.2-9.8.3.390.jar)
+  mekanism.coremod.KeybindingMigrationHelper
+OpenModsCorePlugin (OpenModsLib-1.12.2-0.12.2.jar)
+  openmods.core.OpenModsClassTransformer
+	OpenModsLib class transformers: [llama_null_fix:FINISHED],[horse_base_null_fix:FINISHED],[pre_world_render_hook:FINISHED],[player_render_hook:FINISHED],[horse_null_fix:FINISHED]
+	Ender IO: No known problems detected.
+	Authlib is : /C:/Users/user/AppData/Roaming/.minecraft/libraries/com/mojang/authlib/1.5.25/authlib-1.5.25.jar
+
+	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	!!!You are looking at the diagnostics information, not at the crash.       !!!
+	!!!Scroll up until you see the line with '---- Minecraft Crash Report ----'!!!
+	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
---- Minecraft Crash Report ----

WARNING: coremods are present:
  IELoadingPlugin (ImmersiveEngineering-core-0.12-98.jar)
  Inventory Tweaks Coremod (InventoryTweaks-1.63.jar)
  EnderCorePlugin (EnderCore-1.12.2-0.5.76-core.jar)
  MekanismCoremod (Mekanism-1.12.2-9.8.3.390.jar)
  OpenModsCorePlugin (OpenModsLib-1.12.2-0.12.2.jar)
Contact their authors BEFORE contacting forge

// I bet Cylons wouldn't have this problem.

Time: 4/3/21 12:03 PM
Description: There was a severe problem during mod loading that has caused the game to fail

net.minecraftforge.fml.common.LoaderExceptionModCrash: Caught exception from CodeChicken Lib (codechickenlib)
Caused by: codechicken.lib.configuration.ConfigFile$ConfigException: codechicken.lib.configuration.ConfigParseException: Invalid value type d, @Line:20, dump_asm=true
	at codechicken.lib.configuration.ConfigFile.load(ConfigFile.java:61)
	at codechicken.lib.configuration.ConfigFile.<init>(ConfigFile.java:43)
	at codechicken.lib.configuration.ConfigFile.<init>(ConfigFile.java:29)
	at codechicken.lib.configuration.ConfigFile.<init>(ConfigFile.java:19)
	at codechicken.lib.CodeChickenLib.preInit(CodeChickenLib.java:50)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:637)
	at sun.reflect.GeneratedMethodAccessor8.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:219)
	at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:197)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:136)
	at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:629)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:252)
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:467)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:378)
	at net.minecraft.client.main.Main.main(SourceFile:123)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
Caused by: codechicken.lib.configuration.ConfigParseException: Invalid value type d, @Line:20, dump_asm=true
	at codechicken.lib.configuration.ConfigTag.parseTag(ConfigTag.java:92)
	at codechicken.lib.configuration.ConfigFile.load(ConfigFile.java:59)
	... 44 more


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- System Details --
Details:
	Minecraft Version: 1.12.2
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_51, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 407605128 bytes (388 MB) / 805306368 bytes (768 MB) up to 2147483648 bytes (2048 MB)
	JVM Flags: 8 total; -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xmx2G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=50 -XX:G1HeapRegionSize=32M
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: MCP 9.42 Powered by Forge 14.23.5.2854 46 mods loaded, 46 mods active
	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored

	| State | ID                                | Version                  | Source                                         | Signature                                |
	|:----- |:--------------------------------- |:------------------------ |:---------------------------------------------- |:---------------------------------------- |
	| LCH   | minecraft                         | 1.12.2                   | minecraft.jar                                  | None                                     |
	| LCH   | mcp                               | 9.42                     | minecraft.jar                                  | None                                     |
	| LCH   | FML                               | 8.0.99.99                | forge-1.12.2-14.23.5.2854.jar                  | e3c3d50c7c986df74c645c0ac54639741c90a557 |
	| LCH   | forge                             | 14.23.5.2854             | forge-1.12.2-14.23.5.2854.jar                  | e3c3d50c7c986df74c645c0ac54639741c90a557 |
	| LCH   | openmodscore                      | 0.12.2                   | minecraft.jar                                  | None                                     |
	| LCE   | codechickenlib                    | 3.2.3.358                | CodeChickenLib-1.12.2-3.2.3.358-universal.jar  | f1850c39b2516232a2108a7bd84d1cb5df93b261 |
	| LC    | redstoneflux                      | 2.1.1                    | RedstoneFlux-1.12-2.1.1.1-universal.jar        | None                                     |
	| LC    | cofhcore                          | 4.6.6                    | CoFHCore-1.12.2-4.6.6.1-universal.jar          | None                                     |
	| LC    | cofhworld                         | 1.4.0                    | CoFHWorld-1.12.2-1.4.0.1-universal.jar         | None                                     |
	| LC    | lootablebodies                    | 2.4.0                    | DrCyanosLootableBodies_1.12-2.4.0.jar          | None                                     |
	| LC    | endercore                         | 1.12.2-0.5.76            | EnderCore-1.12.2-0.5.76.jar                    | None                                     |
	| LC    | jei                               | 4.16.1.301               | jei_1.12.2-4.16.1.301.jar                      | None                                     |
	| LC    | thermalfoundation                 | 2.6.7                    | ThermalFoundation-1.12.2-2.6.7.1-universal.jar | None                                     |
	| LC    | thermalexpansion                  | 5.5.7                    | ThermalExpansion-1.12.2-5.5.7.1-universal.jar  | None                                     |
	| LC    | enderio                           | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderiointegrationtic             | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderiobase                       | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderioconduits                   | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderioconduitsappliedenergistics | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderioconduitsopencomputers      | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderioconduitsrefinedstorage     | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderiointegrationforestry        | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderiointegrationticlate         | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderioinvpanel                   | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderiomachines                   | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | enderiopowertools                 | 5.2.66                   | EnderIO-1.12.2-5.2.66.jar                      | None                                     |
	| LC    | forgemultipartcbe                 | 2.6.2.83                 | ForgeMultipart-1.12.2-2.6.2.83-universal.jar   | f1850c39b2516232a2108a7bd84d1cb5df93b261 |
	| LC    | microblockcbe                     | 2.6.2.83                 | ForgeMultipart-1.12.2-2.6.2.83-universal.jar   | None                                     |
	| LC    | minecraftmultipartcbe             | 2.6.2.83                 | ForgeMultipart-1.12.2-2.6.2.83-universal.jar   | None                                     |
	| LC    | inventorytweaks                   | 1.63+release.109.220f184 | InventoryTweaks-1.63.jar                       | 55d2cd4f5f0961410bf7b91ef6c6bf00a766dcbe |
	| LC    | ironchest                         | 1.12.2-7.0.67.844        | ironchest-1.12.2-7.0.72.847.jar                | None                                     |
	| LC    | journeymap                        | 1.12.2-5.7.1             | journeymap-1.12.2-5.7.1-tw.jar                 | None                                     |
	| LC    | mantle                            | 1.12-1.3.3.55            | Mantle-1.12-1.3.3.55.jar                       | None                                     |
	| LC    | mekanism                          | 1.12.2-9.8.3.390         | Mekanism-1.12.2-9.8.3.390.jar                  | None                                     |
	| LC    | mekanismgenerators                | 1.12.2-9.8.3.390         | MekanismGenerators-1.12.2-9.8.3.390.jar        | None                                     |
	| LC    | mekanismtools                     | 1.12.2-9.8.3.390         | MekanismTools-1.12.2-9.8.3.390.jar             | None                                     |
	| LC    | mtrm                              | 1.2.2.30                 | MineTweakerRecipeMaker-1.12.2-1.2.2.30.jar     | None                                     |
	| LC    | mrtjpcore                         | 2.1.4.43                 | MrTJPCore-1.12.2-2.1.4.43-universal.jar        | None                                     |
	| LC    | openmods                          | 0.12.2                   | OpenModsLib-1.12.2-0.12.2.jar                  | d2a9a8e8440196e26a268d1f3ddc01b2e9c572a5 |
	| LC    | openblocks                        | 1.8.1                    | OpenBlocks-1.12.2-1.8.1.jar                    | d2a9a8e8440196e26a268d1f3ddc01b2e9c572a5 |
	| LC    | projectred-core                   | 4.9.4.120                | ProjectRed-1.12.2-4.9.4.120-Base.jar           | None                                     |
	| LC    | projectred-compat                 | 1.0                      | ProjectRed-1.12.2-4.9.4.120-compat.jar         | None                                     |
	| LC    | projectred-integration            | 4.9.4.120                | ProjectRed-1.12.2-4.9.4.120-integration.jar    | None                                     |
	| LC    | projectred-transmission           | 4.9.4.120                | ProjectRed-1.12.2-4.9.4.120-integration.jar    | None                                     |
	| LC    | thermaldynamics                   | 2.5.6                    | ThermalDynamics-1.12.2-2.5.6.1-universal.jar   | None                                     |
	| LC    | immersiveengineering              | 0.12-98                  | ImmersiveEngineering-0.12-98.jar               | None                                     |

	Loaded coremods (and transformers): 
IELoadingPlugin (ImmersiveEngineering-core-0.12-98.jar)
  blusunrize.immersiveengineering.common.asm.IEClassTransformer
Inventory Tweaks Coremod (InventoryTweaks-1.63.jar)
  invtweaks.forge.asm.ContainerTransformer
EnderCorePlugin (EnderCore-1.12.2-0.5.76-core.jar)
  com.enderio.core.common.transform.EnderCoreTransformer
  com.enderio.core.common.transform.SimpleMixinPatcher
MekanismCoremod (Mekanism-1.12.2-9.8.3.390.jar)
  mekanism.coremod.KeybindingMigrationHelper
OpenModsCorePlugin (OpenModsLib-1.12.2-0.12.2.jar)
  openmods.core.OpenModsClassTransformer
	OpenModsLib class transformers: [llama_null_fix:FINISHED],[horse_base_null_fix:FINISHED],[pre_world_render_hook:FINISHED],[player_render_hook:FINISHED],[horse_null_fix:FINISHED]
	Ender IO: No known problems detected.
	Authlib is : /C:/Users/user/AppData/Roaming/.minecraft/libraries/com/mojang/authlib/1.5.25/authlib-1.5.25.jar

	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
	!!!You are looking at the diagnostics information, not at the crash.       !!!
	!!!Scroll up until you see the line with '---- Minecraft Crash Report ----'!!!
	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
