### PR TITLE
Add support for procedural textures as a replacement for TextureFX.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ if (System.getenv("KEY_STORE")) {
     println 'No signing secrets found, build will not be signed.'
 }
 
-config.mod_version = "${config.mod_version}." + (System.getenv("BUILD_NUMBER") ?: "417")
+config.mod_version = "${config.mod_version}." + (System.getenv("BUILD_NUMBER") ?: "1")
 version = "${config.mc_version}-${config.mod_version}"
 println "Starting build of ${archivesBaseName}, Version: ${config.mod_version}"
 println "Using Forge: ${config.forge_version}, for Minecraft: ${config.mc_version}, with Mappings: ${config.mappings}"

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ if (System.getenv("KEY_STORE")) {
     println 'No signing secrets found, build will not be signed.'
 }
 
-config.mod_version = "${config.mod_version}." + (System.getenv("BUILD_NUMBER") ?: "1")
+config.mod_version = "${config.mod_version}." + (System.getenv("BUILD_NUMBER") ?: "417")
 version = "${config.mc_version}-${config.mod_version}"
 println "Starting build of ${archivesBaseName}, Version: ${config.mod_version}"
 println "Using Forge: ${config.forge_version}, for Minecraft: ${config.mc_version}, with Mappings: ${config.mappings}"

--- a/build.properties
+++ b/build.properties
@@ -1,3 +1,3 @@
 mc_version=1.16.5
 forge_version=36.1.0
-mod_version=4.0.0
+mod_version=4.0.1

--- a/src/main/java/codechicken/lib/colour/Colour.java
+++ b/src/main/java/codechicken/lib/colour/Colour.java
@@ -140,6 +140,20 @@ public abstract class Colour implements Copyable<Colour> {
         return this;
     }
 
+    /**
+     * Flips a color between ABGR and RGBA.
+     *
+     * @param colour The input either ABGR or RGBA.
+     * @return The flipped color.
+     */
+    public static int flipABGR(int colour) {
+        int a = (colour >> 24) & 0xFF;
+        int b = (colour >> 16) & 0xFF;
+        int c = (colour >> 8) & 0xFF;
+        int d = colour & 0xFF;
+        return (d & 0xFF) << 24 | (c & 0xFF) << 16 | (b & 0xFF) << 8 | (a & 0xFF);
+    }
+
     public static int[] unpack(int colour) {
         return new int[] { (colour >> 24) & 0xFF, (colour >> 16) & 0xFF, (colour >> 8) & 0xFF, colour & 0xFF };
     }

--- a/src/main/java/codechicken/lib/texture/AtlasRegistrar.java
+++ b/src/main/java/codechicken/lib/texture/AtlasRegistrar.java
@@ -20,6 +20,16 @@ public interface AtlasRegistrar {
     void registerSprite(ResourceLocation loc, Consumer<TextureAtlasSprite> onReady);
 
     /**
+     * Called to register a sprite, a procedural callback and a callback for when the TextureAtlasSprite has been loaded.
+     * The procedural callback allows for dynamically generating texture data.
+     *
+     * @param loc       The sprite's dummy ResourceLocation.
+     * @param cycleFunc The callback for updating the texture data dynamically.
+     * @param onReady   The callback for the sprite being ready.
+     */
+    void registerProceduralSprite(ResourceLocation loc, Consumer<ProceduralTexture> cycleFunc, Consumer<TextureAtlasSprite> onReady);
+
+    /**
      * Same as above, just takes a String for the ResourceLocation instead.
      *
      * @param loc     The sprite's ResourceLocation.

--- a/src/main/java/codechicken/lib/texture/ProceduralTexture.java
+++ b/src/main/java/codechicken/lib/texture/ProceduralTexture.java
@@ -1,0 +1,68 @@
+package codechicken.lib.texture;
+
+import codechicken.lib.colour.Colour;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.AtlasTexture;
+import net.minecraft.client.renderer.texture.MipmapGenerator;
+import net.minecraft.client.renderer.texture.NativeImage;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+
+import java.util.function.Consumer;
+
+/**
+ * Created by KitsuneAlex on 14/4/21.
+ */
+public class ProceduralTexture extends TextureAtlasSprite {
+
+    private final Consumer<ProceduralTexture> cycleFunc;
+
+    public ProceduralTexture(AtlasTexture atlas, TextureAtlasSprite other, Consumer<ProceduralTexture> cycleFunc) {
+        this(atlas, other.info, other.mainImage.length - 1, 1, 1, other.x, other.y, other.mainImage[0], cycleFunc);
+        this.u0 = other.u0;
+        this.u1 = other.u1;
+        this.v0 = other.v0;
+        this.v1 = other.v1;
+    }
+
+    private ProceduralTexture(AtlasTexture atlas, Info info, int mipmapLevels, int storageX, int storageY, int x, int y, NativeImage image, Consumer<ProceduralTexture> cycleFunc) {
+        super(atlas, info, mipmapLevels, storageX, storageY, x, y, image);
+        this.cycleFunc = cycleFunc;
+    }
+
+    @Override
+    public void cycleFrames() {
+        cycleFunc.accept(this);
+
+        int levels = mainImage.length - 1;
+
+        if (levels > 0) {
+            NativeImage[] mipped = MipmapGenerator.generateMipLevels(mainImage[0], levels);
+            System.arraycopy(mipped, 0, mainImage, 0, mipped.length);
+        }
+
+        uploadFirstFrame();
+    }
+
+    /**
+     * Gets the RGBA value of a given pixel.
+     *
+     * @param x The X coord.
+     * @param y The Y coord.
+     * @return The RGBA pixel value.
+     */
+    public int getPixel(int x, int y) {
+        return Colour.flipABGR(mainImage[0].getPixelRGBA(x, y));// Flip to RGBA..
+    }
+
+    /**
+     * Sets the RGBA value of a given pixel.
+     *
+     * @param x The X coord.
+     * @param y The Y coord.
+     * @param rgba The RGBA pixel value.
+     */
+    public void setPixel(int x, int y, int rgba) {
+        mainImage[0].setPixelRGBA(x, y, Colour.flipABGR(rgba));// Flip to ABGR..
+    }
+
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -29,3 +29,14 @@ public-f net.minecraft.client.renderer.BlockRendererDispatcher field_175028_a # 
 public-f net.minecraft.client.Minecraft field_175618_aM # blockRenderDispatcher
 public net.minecraft.client.renderer.ItemRenderer func_229114_a_(Lnet/minecraft/client/renderer/model/IBakedModel;Lnet/minecraft/item/ItemStack;IILcom/mojang/blaze3d/matrix/MatrixStack;Lcom/mojang/blaze3d/vertex/IVertexBuilder;)V # renderModel
 public net.minecraft.item.ArmorMaterial field_77882_bY # MAX_DAMAGE_ARRAY
+
+public net.minecraft.client.renderer.texture.TextureAtlasSprite field_195670_c # mainImage
+public net.minecraft.client.renderer.texture.TextureAtlasSprite field_229226_c_ # info
+public net.minecraft.client.renderer.texture.TextureAtlasSprite field_110975_c # x
+public net.minecraft.client.renderer.texture.TextureAtlasSprite field_110974_d # y
+public-f net.minecraft.client.renderer.texture.TextureAtlasSprite field_110979_l # u0
+public-f net.minecraft.client.renderer.texture.TextureAtlasSprite field_110980_m # u1
+public-f net.minecraft.client.renderer.texture.TextureAtlasSprite field_110977_n # v0
+public-f net.minecraft.client.renderer.texture.TextureAtlasSprite field_110978_o # v1
+public net.minecraft.client.renderer.texture.AtlasTexture field_94258_i # animatedTextures
+public net.minecraft.client.renderer.texture.AtlasTexture field_94252_e # texturesByName


### PR DESCRIPTION
This adds a simple way of implementing procedurally generated textures.

The implementation uses two Mixins because they allow for the most efficient implementation in this case.