### PR TITLE
Prioritize global ICCBlockRenderers

### DIFF
--- a/src/main/java/codechicken/lib/render/block/BlockRenderingRegistry.java
+++ b/src/main/java/codechicken/lib/render/block/BlockRenderingRegistry.java
@@ -96,27 +96,29 @@ public class BlockRenderingRegistry {
 
     @Nullable
     static ICCBlockRenderer findFor(Block block, Predicate<ICCBlockRenderer> pred) {
-        ICCBlockRenderer found = blockRenderers.get(block.delegate);
-        if (found != null && pred.test(found)) return found;
-
         for (ICCBlockRenderer renderer : globalRenderers) {
             if (pred.test(renderer)) {
                 return renderer;
             }
         }
+
+        ICCBlockRenderer found = blockRenderers.get(block.delegate);
+        if (found != null && pred.test(found)) return found;
+
         return null;
     }
 
     @Nullable
     static ICCBlockRenderer findFor(Fluid fluid, Predicate<ICCBlockRenderer> pred) {
-        ICCBlockRenderer found = fluidRenderers.get(fluid.delegate);
-        if (found != null && pred.test(found)) return found;
-
         for (ICCBlockRenderer renderer : globalRenderers) {
             if (pred.test(renderer)) {
                 return renderer;
             }
         }
+
+        ICCBlockRenderer found = fluidRenderers.get(fluid.delegate);
+        if (found != null && pred.test(found)) return found;
+
         return null;
     }
 }


### PR DESCRIPTION
Since overriding existing block rendering is one of the features of global ICCBlockRenderers, it makes sense to check them first. Otherwise, they cannot override other *non-global* renderers.