### PR TITLE
Fix build by removing unnecessary private field access

### DIFF
--- a/src/main/java/codechicken/lib/inventory/container/SlotDummy.java
+++ b/src/main/java/codechicken/lib/inventory/container/SlotDummy.java
@@ -24,7 +24,7 @@ public class SlotDummy extends SlotHandleClicks {
 
     @Override
     public void slotClick(ContainerExtended container, Player player, int button, ClickType clickType) {
-        ItemStack held = player.inventory.player.containerMenu.getCarried();
+        ItemStack held = player.getInventory().player.containerMenu.getCarried();
         boolean shift = clickType == ClickType.QUICK_MOVE;
         slotClick(held, button, shift);
     }


### PR DESCRIPTION
Private field was accidentally accessed without an access transformer in place. Changed to use getter instead of adding the AT unnecessarily.