### PR TITLE
Deprecate block model bypass hax for removal. Embed embeddium compat.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ repositories {
     mavenLocal()
     maven { url "https://maven.covers1624.net/" }
     maven { url "https://maven.blamejared.com/" }
+    maven { url "https://api.modrinth.com/maven" }
 }
 
 dependencies {
@@ -82,6 +83,8 @@ dependencies {
             prefer '0.4.10.105'
         }
     }
+
+    compileOnly 'maven.modrinth:embeddium:1.0.15+mc1.21.1'
 
     compileOnly("mezz.jei:jei-${mc_version}-neoforge:${jei_version}") {
         transitive false

--- a/src/main/java/codechicken/lib/internal/mixin/EmbeddiumCCLMixin.java
+++ b/src/main/java/codechicken/lib/internal/mixin/EmbeddiumCCLMixin.java
@@ -1,0 +1,21 @@
+package codechicken.lib.internal.mixin;
+
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import org.embeddedt.embeddium.compat.ccl.CCLCompat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+/**
+ * Created by covers1624 on 2/7/25.
+ */
+@Mixin (CCLCompat.class)
+public class EmbeddiumCCLMixin {
+
+    /**
+     * @author covers1624
+     * @reason Its broken and CCL ships its own.
+     */
+    @Overwrite
+    public static void onClientSetup(FMLClientSetupEvent event) {
+    }
+}

--- a/src/main/java/codechicken/lib/internal/mixin/compat/EmbeddiumCCLMixin.java
+++ b/src/main/java/codechicken/lib/internal/mixin/compat/EmbeddiumCCLMixin.java
@@ -1,15 +1,17 @@
-package codechicken.lib.internal.mixin;
+package codechicken.lib.internal.mixin.compat;
 
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import org.embeddedt.embeddium.compat.ccl.CCLCompat;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Pseudo;
 
 /**
  * Created by covers1624 on 2/7/25.
  */
+@Pseudo
 @Mixin (CCLCompat.class)
-public class EmbeddiumCCLMixin {
+abstract class EmbeddiumCCLMixin {
 
     /**
      * @author covers1624

--- a/src/main/java/codechicken/lib/render/block/CCBlockRendererDispatcher.java
+++ b/src/main/java/codechicken/lib/render/block/CCBlockRendererDispatcher.java
@@ -26,12 +26,15 @@ import net.neoforged.neoforge.client.model.data.ModelData;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * Created by covers1624 on 8/09/2016.
  */
+@Deprecated
+@ScheduledForRemoval (inVersion = "mc 1.21.2+")
 public class CCBlockRendererDispatcher extends BlockRenderDispatcher {
 
     private static final Logger logger = LogManager.getLogger();

--- a/src/main/java/codechicken/lib/render/block/ICCBlockRenderer.java
+++ b/src/main/java/codechicken/lib/render/block/ICCBlockRenderer.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.neoforged.neoforge.client.model.data.ModelData;
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,7 +23,14 @@ import org.jetbrains.annotations.Nullable;
  * Created by covers1624 on 8/09/2016.
  *
  * @see BlockRenderingRegistry
+ * @deprecated Unfortunately, this has become a maintenance and compatability burden. Mods like Sodium
+ * are in every single modpack, and we can't realistically tell people not to use it. It's possible
+ * a Neo api may pop up that allows features similar to this API. But I'm not going to hold my breath.
+ * If someone still requires the functionality that this system provides, they should implement mixins
+ * themselves, or Sodium/Embeddium compatability.
  */
+@Deprecated (forRemoval = true)
+@ScheduledForRemoval (inVersion = "mc 1.21.2+")
 public interface ICCBlockRenderer {
 
     //region Block
@@ -36,6 +44,7 @@ public interface ICCBlockRenderer {
      * @param renderType The {@link RenderType}, {@code null} for breaking.
      * @return If you wish to render the BlockState.
      */
+    @Deprecated
     boolean canHandleBlock(BlockAndTintGetter world, BlockPos pos, BlockState blockState, @Nullable RenderType renderType);
 
     /**
@@ -53,6 +62,7 @@ public interface ICCBlockRenderer {
      * @param data       Any ModelData.
      * @param renderType The {@link RenderType}, {@code null} for breaking.
      */
+    @Deprecated
     void renderBlock(BlockState state, BlockPos pos, BlockAndTintGetter world, PoseStack mStack, VertexConsumer builder, RandomSource random, ModelData data, @Nullable RenderType renderType);
 
     /**
@@ -66,6 +76,7 @@ public interface ICCBlockRenderer {
      * @param builder The {@link VertexConsumer} to add quads to.
      * @param data    Any ModelData.
      */
+    @Deprecated
     default void renderBreaking(BlockState state, BlockPos pos, BlockAndTintGetter world, PoseStack mStack, VertexConsumer builder, ModelData data) {
         CCRenderState ccrs = CCRenderState.instance();
         ccrs.overlay = OverlayTexture.NO_OVERLAY;
@@ -85,6 +96,7 @@ public interface ICCBlockRenderer {
      * @param state The state.
      * @return If you wish to render this block.
      */
+    @Deprecated // No replacement. Use a mixin.
     default boolean canHandleEntity(BlockState state) {
         return false;
     }
@@ -101,6 +113,7 @@ public interface ICCBlockRenderer {
      * @param data          Any ModelData.
      * @param renderType    The {@link RenderType} may be {@code null}.
      */
+    @Deprecated // No replacement. Use a mixin.
     default void renderEntity(BlockState state, PoseStack nStack, MultiBufferSource builder, int packedLight, int packedOverlay, ModelData data, @Nullable RenderType renderType) { }
     //endregion
 
@@ -115,6 +128,7 @@ public interface ICCBlockRenderer {
      * @param fluidState The {@link FluidState}.
      * @return If you wish to render the {@link FluidState}.
      */
+    @Deprecated // No replacement. Use a mixin.
     default boolean canHandleFluid(BlockAndTintGetter world, BlockPos pos, BlockState blockState, FluidState fluidState) {
         return false;
     }
@@ -131,6 +145,7 @@ public interface ICCBlockRenderer {
      * @param blockState The {@link BlockState}
      * @param fluidState The {@link FluidState}
      */
+    @Deprecated // No replacement. Use a mixin.
     default void renderFluid(BlockPos pos, BlockAndTintGetter world, VertexConsumer builder, BlockState blockState, FluidState fluidState) { }
     //endregion
 }

--- a/src/main/resources/mixins.codechickenlib.json
+++ b/src/main/resources/mixins.codechickenlib.json
@@ -9,6 +9,7 @@
         "dev.GameNarratorMixin",
         "ItemRendererMixin",
         "MinecraftMixin",
-        "ShaderInstanceMixin"
+        "ShaderInstanceMixin",
+        "EmbeddiumCCLMixin"
     ]
 }

--- a/src/main/resources/mixins.codechickenlib.json
+++ b/src/main/resources/mixins.codechickenlib.json
@@ -10,6 +10,6 @@
         "ItemRendererMixin",
         "MinecraftMixin",
         "ShaderInstanceMixin",
-        "EmbeddiumCCLMixin"
+        "compat.EmbeddiumCCLMixin"
     ]
 }


### PR DESCRIPTION
Changes:
- Pull in Embeddium compatability.
- Deprecate the entire model bypass system for removal.

TODO:
- [ ] Ask embeddium very kindly (or PR) to remove all their CCL compat so my mixin can die.